### PR TITLE
Pin free floating versions

### DIFF
--- a/charts/projectriff-riff.yaml
+++ b/charts/projectriff-riff.yaml
@@ -1,5 +1,5 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
-knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.0/serving.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/riff-system-0.1.0-snapshot.yaml
-riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot.yaml
-riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot.yaml
+knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-afb8a6d9901d988355b1f64328a657ac44cf4640.yaml
+riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-ci-9321733d81b0.yaml
+riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-ci-9321733d81b0.yaml


### PR DESCRIPTION
Snapshot versions are replaced as there are new builds. This means that
we don't know exactly what is going into each chart. By pinning the
snapshot version to include a sha, we can lockdown the chart.

This also means that we'll need to update the chart whenever we need to
pick up a change. In time we can automate this process.