### PR TITLE
Maintainable pinned template versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ repository: charts/fetch-istio.sh charts/package.sh
 	./charts/package.sh istio ${VERSION} repository
 	./charts/package.sh riff ${VERSION} repository
 
+.PHONY: templates
+templates:
+	./charts/update-template.sh riff
+
 .PHONY: clean
 clean:
 	rm -rf repository

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ kubectl delete namespace istio-system
 
 ### Steps
 
+Optionally, update the chart templates to the latest component builds.
+
+```sh
+make templates
+```
+
 Package charts locally. Charts will be placed in the `repository` directory.
 
 ```sh

--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,5 +1,5 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
 knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
 riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-afb8a6d9901d988355b1f64328a657ac44cf4640.yaml
-riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-ci-4a384016d7b9.yaml
-riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-ci-4a384016d7b9.yaml
+riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-ci-64093473b1bc.yaml
+riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-ci-64093473b1bc.yaml

--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,5 +1,5 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
 knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-afb8a6d9901d988355b1f64328a657ac44cf4640.yaml
-riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-ci-64093473b1bc.yaml
-riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-ci-64093473b1bc.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-54bc9eb07f7907a28d5518b9a486467fe06a7601.yaml
+riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-ci-53653e947e5e.yaml
+riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-ci-53653e947e5e.yaml

--- a/charts/riff/templates.yaml.tpl
+++ b/charts/riff/templates.yaml.tpl
@@ -1,5 +1,5 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
 knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-afb8a6d9901d988355b1f64328a657ac44cf4640.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
 riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
 riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml

--- a/charts/riff/templates.yaml.tpl
+++ b/charts/riff/templates.yaml.tpl
@@ -1,0 +1,5 @@
+knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
+knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-afb8a6d9901d988355b1f64328a657ac44cf4640.yaml
+riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
+riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml

--- a/charts/update-template.sh
+++ b/charts/update-template.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+chart=$1
+
+chart_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/${chart}"
+
+if [ -f $chart_dir/templates.yaml.tpl ] ; then
+  rm  $chart_dir/templates.yaml
+  while IFS= read -r line
+  do
+    eval "echo \"${line}\" >> $chart_dir/templates.yaml"
+  done < "$chart_dir/templates.yaml.tpl"
+fi


### PR DESCRIPTION
This adds template file that creates the templates.yaml file. (A bit
meta templating the config that defines how to chart's templates are
defined)

The `{chart}/templates.yaml.tpl` may contain bash expressions which are
resolved and inlined into the output file. The `make templates` target
will update existing chart templates. The output of this target should
be committed to the repo and pass CI before publishing a chart.

Running `make templates` is currently manual, but may be automated in
the future.