### PR TITLE
Add timestamp and short gitsha to version slugs

### DIFF
--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,5 +1,5 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
 knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-54bc9eb07f7907a28d5518b9a486467fe06a7601.yaml
-riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-ci-53653e947e5e.yaml
-riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-ci-53653e947e5e.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-20190719023833-dcba68696ba1e5d4.yaml
+riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-20190719030421-5567e448e83d1fa6.yaml
+riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-20190719030421-5567e448e83d1fa6.yaml

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -4,14 +4,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-version=`cat VERSION`
-commit=$(git rev-parse HEAD)
+readonly version=$(cat VERSION)
+readonly git_sha=$(git rev-parse HEAD)
+readonly git_timestamp=$(TZ=UTC git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
+readonly slug=${version}-${git_timestamp}-${git_sha:0:16}
 
 make clean
 mkdir -p repository
 gsutil cp gs://projectriff/charts/releases/index.yaml repository/
-gsutil cp gs://projectriff/charts/snapshots/*-${version}-${commit}.tgz repository/
-for f in repository/*.tgz; do mv $f $(echo $f | sed s/${version}-${commit}/${version}/); done
+gsutil cp gs://projectriff/charts/snapshots/*-${slug}.tgz repository/
+for f in repository/*.tgz; do mv $f $(echo $f | sed s/${slug}/${version}/); done
 
 helm repo index repository/ --url https://projectriff.storage.googleapis.com/charts/releases --merge repository/index.yaml
 gsutil cp -a public-read repository/*.tgz gs://projectriff/charts/releases/

--- a/ci/stage.sh
+++ b/ci/stage.sh
@@ -4,11 +4,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-version=`cat VERSION`
-commit=$(git rev-parse HEAD)
+readonly version=$(cat VERSION)
+readonly git_sha=$(git rev-parse HEAD)
+readonly git_timestamp=$(TZ=UTC git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
+readonly slug=${version}-${git_timestamp}-${git_sha:0:16}
 
 helm init --client-only
 make clean package
 
-for f in repository/*.tgz; do mv $f $(echo $f | sed s/${version}/${version}-${commit}/); done
+for f in repository/*.tgz; do mv $f $(echo $f | sed s/${version}/${slug}/); done
 gsutil cp -a public-read repository/*.tgz gs://projectriff/charts/snapshots/


### PR DESCRIPTION
The new format is `{version}-{date}-{sha}`, for example
`0.1.0-snapshot-201907190202-584c6a1d7b6e76f1`