### PR TITLE
Make Knative runtime opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Helm charts to install Istio and riff.
    helm repo update
    ```
 
-1. Install Istio
+1. Install Istio (optional, required for the Knative runtime)
 
    Append:
 
@@ -44,6 +44,7 @@ Helm charts to install Istio and riff.
 
    Append:
 
+   - `--set knative.enabled=true` to enable the Knative runtime
    - `--devel` for the latest snapshot.
 
    ```sh
@@ -59,7 +60,7 @@ Helm charts to install Istio and riff.
 helm delete --purge riff
 kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=riff
 
-# remove istio
+# remove istio (if installed)
 helm delete --purge istio
 kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=istio
 kubectl delete namespace istio-system

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
   variables:
     CLUSTER:  'minikube'
-    REGISTRY: 'daemon'
+    REGISTRY: 'docker-daemon'
     CLUSTER_NAME: 'charts-$(Build.BuildId)-minikube'
     NAMESPACE: '$(CLUSTER_NAME)'
     RUNTIME: core

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   fatsDir: '$(system.defaultWorkingDirectory)/../fats'
   fatsRepo: projectriff/fats
-  fatsRefspec: 4d76fb0d29c92bc5cf560c3d94042e1e46355048 # master as of 2019-08-08
+  fatsRefspec: runtimes # TODO get back to master
   tillerNamespace: kube-system
   tillerServiceAccount: tiller
 
@@ -15,6 +15,10 @@ jobs:
     REGISTRY: 'minikube'
     CLUSTER_NAME: 'charts-$(Build.BuildId)-minikube'
     NAMESPACE: '$(CLUSTER_NAME)'
+    RUNTIME: core
+    FATS_DIR: $(fatsDir)
+    FATS_REPO: $(fatsRepo)
+    FATS_REFSPEC: $(fatsRefspec)
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
   steps:
   - bash: ./ci/fats-fetch.sh $(fatsDir) $(fatsRefspec) $(fatsRepo)
@@ -33,15 +37,9 @@ jobs:
   - bash: $(fatsDir)/start.sh
     displayName: 'Start FATS'
   - bash: ./ci/install-riff.sh ./repository/istio-$(cat VERSION).tgz ./repository/riff-$(cat VERSION).tgz
-    env:
-      FATS_DIR: $(fatsDir)
     displayName: 'Install riff'
   - bash: ./ci/run-tests.sh
     displayName: 'Run tests'
-    env:
-      FATS_DIR: $(fatsDir)
-      FATS_REPO: $(fatsRepo)
-      FATS_REFSPEC: $(fatsRefspec)
   - bash: ci/diagnostics.sh
     condition: failed()
     displayName: 'Collect diagnostics'
@@ -81,11 +79,13 @@ jobs:
         qualifier: minikube
         cluster: minikube
         registry: dockerhub
+        runtime: core
       gke:
         imageName: ubuntu-16.04
         qualifier: gke
         cluster: gke
         registry: gcr
+        runtime: knative
   pool:
     vmImage: $(imageName)
   variables:
@@ -93,6 +93,10 @@ jobs:
     REGISTRY: '$(registry)'
     CLUSTER_NAME: 'charts-$(Build.BuildId)-$(qualifier)'
     NAMESPACE: '$(CLUSTER_NAME)'
+    RUNTIME: '$(runtime)'
+    FATS_DIR: $(fatsDir)
+    FATS_REPO: $(fatsRepo)
+    FATS_REFSPEC: $(fatsRefspec)
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   steps:
   - bash: ./ci/fats-fetch.sh $(fatsDir) $(fatsRefspec) $(fatsRepo)
@@ -116,7 +120,6 @@ jobs:
       DOCKER_USERNAME: '$(DockerUsername)'
       DOCKER_PASSWORD: '$(DockerPassword)'
       GCLOUD_CLIENT_SECRET: '$(GcloudClientSecret)'
-      FATS_DIR: $(fatsDir)
     displayName: 'Install riff'
   - bash: ./ci/run-tests.sh
     displayName: 'Run tests'
@@ -124,9 +127,6 @@ jobs:
       DOCKER_USERNAME: '$(DockerUsername)'
       DOCKER_PASSWORD: '$(DockerPassword)'
       GCLOUD_CLIENT_SECRET: '$(GcloudClientSecret)'
-      FATS_DIR: $(fatsDir)
-      FATS_REPO: $(fatsRepo)
-      FATS_REFSPEC: $(fatsRefspec)
   - bash: ci/diagnostics.sh
     condition: failed()
     displayName: 'Collect diagnostics'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
   variables:
     CLUSTER:  'minikube'
-    REGISTRY: 'minikube'
+    REGISTRY: 'daemon'
     CLUSTER_NAME: 'charts-$(Build.BuildId)-minikube'
     NAMESPACE: '$(CLUSTER_NAME)'
     RUNTIME: core

--- a/charts/knative/templates.yaml
+++ b/charts/knative/templates.yaml
@@ -1,2 +1,1 @@
-knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
-knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
+knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml # --data-value dropKnativeImageCRD=true

--- a/charts/knative/templates.yaml.tpl
+++ b/charts/knative/templates.yaml.tpl
@@ -1,2 +1,1 @@
-knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml # --data-value dropKnativeImageCRD=true
-knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml
+knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml # --data-value dropKnativeImageCRD=true

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -54,7 +54,7 @@ if [ -f ${chart_dir}/requirements.yaml ] ; then
 fi
 
 if [ -d ${chart_dir}/charts ] ; then
-  mkdir ${build_dir}/charts
+  mkdir -p ${build_dir}/charts
   cp -LR ${chart_dir}/charts/* ${build_dir}/charts/
 fi
 

--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,3 +1,4 @@
+knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml
 riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-20190809014550-2ab4df7b13f05a9d.yaml
 riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-20190723101418-eebd39e67fd466b2.yaml
 riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-20190723101418-eebd39e67fd466b2.yaml

--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,4 +1,4 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-20190812162736-2a34f29c3ae1cd45.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-20190812203339-761546c729628783.yaml
 riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-20190723101418-eebd39e67fd466b2.yaml
 riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-20190723101418-eebd39e67fd466b2.yaml

--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,4 +1,4 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-20190809014550-2ab4df7b13f05a9d.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.1.0-snapshot-20190812162736-2a34f29c3ae1cd45.yaml
 riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.3.0-snapshot-20190723101418-eebd39e67fd466b2.yaml
 riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.3.0-snapshot-20190723101418-eebd39e67fd466b2.yaml

--- a/charts/riff/templates.yaml.tpl
+++ b/charts/riff/templates.yaml.tpl
@@ -1,3 +1,4 @@
+knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml
 riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
 riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
 riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml

--- a/charts/riff/values.yaml
+++ b/charts/riff/values.yaml
@@ -1,3 +1,3 @@
 ---
 knative:
-  enabled: true
+  enabled: false

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -20,5 +20,12 @@ kubectl create serviceaccount ${tiller_service_account} -n ${tiller_namespace}
 kubectl create clusterrolebinding "${tiller_service_account}-cluster-admin" --clusterrole cluster-admin --serviceaccount "${tiller_namespace}:${tiller_service_account}"
 helm init --wait --service-account ${tiller_service_account}
 
-helm install ${istio_chart} --name istio --namespace istio-system --devel --wait --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
-helm install ${riff_chart} --name riff --devel --set knative.enabled=true
+if [ $RUNTIME = "core" ]; then
+  helm install ${riff_chart} --name riff --devel
+elif [ $RUNTIME = "knative" ]; then
+  helm install ${istio_chart} --name istio --namespace istio-system --devel --wait --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
+  helm install ${riff_chart} --name riff --devel --set knative.enabled=true
+
+  echo "Checking for ready ingress"
+  wait_for_ingress_ready 'istio-ingressgateway' 'istio-system'
+fi

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -21,4 +21,4 @@ kubectl create clusterrolebinding "${tiller_service_account}-cluster-admin" --cl
 helm init --wait --service-account ${tiller_service_account}
 
 helm install ${istio_chart} --name istio --namespace istio-system --devel --wait --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
-helm install ${riff_chart} --name riff --devel
+helm install ${riff_chart} --name riff --devel --set knative.enabled=true

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -7,9 +7,6 @@ set -o pipefail
 source $FATS_DIR/.configure.sh
 source $FATS_DIR/functions/helpers.sh
 
-echo "Checking for ready ingress"
-wait_for_ingress_ready 'istio-ingressgateway' 'istio-system'
-
 # setup namespace
 kubectl create namespace $NAMESPACE
 fats_create_push_credentials $NAMESPACE
@@ -21,6 +18,7 @@ for test in java java-boot node npm command; do
   create_args="--git-repo https://github.com/${FATS_REPO}.git --git-revision ${FATS_REFSPEC} --sub-path functions/uppercase/${test}"
   input_data=charts
   expected_data=CHARTS
+  runtime=$RUNTIME
 
-  run_function $path $function_name $image "$create_args" $input_data $expected_data
+  run_function $path $function_name $image "$create_args" $input_data $expected_data $runtime
 done


### PR DESCRIPTION
Knative Build is always included with the riff chart. Knative Serving is
now opt-in as part of the Knative runtime. Istio is only needed if the
Knative runtime is also installed.

Depends on:
- https://github.com/projectriff/system/pull/40
- https://github.com/projectriff/system/pull/41
- https://github.com/projectriff/system/pull/46
- https://github.com/projectriff/fats/pull/175