### PR TITLE
Add app-version to knative and riff charts

### DIFF
--- a/charts/knative/Chart.yaml
+++ b/charts/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-appVersion: 0.7.1
+appVersion: 0.7
 description: riff support for Knative
 home: https://projectriff.io
 sources:

--- a/charts/knative/Chart.yaml
+++ b/charts/knative/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 name: knative
+appVersion: 0.7.1
 description: riff support for Knative
 home: https://projectriff.io
 sources:

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -58,4 +58,8 @@ if [ -d ${chart_dir}/charts ] ; then
   cp -LR ${chart_dir}/charts/* ${build_dir}/charts/
 fi
 
-helm package ${build_dir} --destination ${destination} --version ${version}
+if [ ${chart} == 'riff' ] ; then
+  helm package ${build_dir} --destination ${destination} --version ${version} --app-version ${version}
+else
+  helm package ${build_dir} --destination ${destination} --version ${version}
+fi


### PR DESCRIPTION
- knative version is currently set to 0.7.1

Alternative to #27 

Fixes #25 
