### PR TITLE
Require tiller 2.14+

### DIFF
--- a/charts/knative/Chart.yaml
+++ b/charts/knative/Chart.yaml
@@ -6,3 +6,4 @@ home: https://projectriff.io
 sources:
   - https://github.com/knative
 icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff/Chart.yaml
+++ b/charts/riff/Chart.yaml
@@ -9,3 +9,4 @@ home: https://projectriff.io
 sources:
   - https://github.com/projectriff
 icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'


### PR DESCRIPTION
Versions prior to 2.10 are known to fail. We test with 2.14, so setting
the bar there.