### PR TITLE
Add charts for kpack and riff-builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ repository: charts/fetch-istio.sh charts/package.sh
 	./charts/fetch-istio.sh istio 1.2.5
 	./charts/package.sh istio ${VERSION} repository
 	./charts/package.sh knative ${VERSION} repository
+	./charts/package.sh kpack ${VERSION} repository
+	./charts/package.sh riff-builders ${VERSION} repository
 	./charts/package.sh riff ${VERSION} repository
 	./charts/package.sh riff-build ${VERSION} repository
 	./charts/package.sh riff-core-runtime ${VERSION} repository
@@ -17,6 +19,8 @@ repository: charts/fetch-istio.sh charts/package.sh
 .PHONY: templates
 templates:
 	./charts/update-template.sh knative
+	./charts/update-template.sh kpack
+	./charts/update-template.sh riff-builders
 	./charts/update-template.sh riff
 	./charts/update-template.sh riff-build
 	./charts/update-template.sh riff-core-runtime

--- a/charts/kpack/Chart.yaml
+++ b/charts/kpack/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: kpack
+appVersion: 0.0.4
+description: riff support for kpack
+home: https://projectriff.io
+sources:
+  - https://github.com/pivotal/kpack
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/kpack/templates.yaml
+++ b/charts/kpack/templates.yaml
@@ -1,0 +1,1 @@
+kpack: https://github.com/pivotal/kpack/releases/download/v0.0.4/release-0.0.4.yaml

--- a/charts/kpack/templates.yaml.tpl
+++ b/charts/kpack/templates.yaml.tpl
@@ -1,0 +1,1 @@
+kpack: https://github.com/pivotal/kpack/releases/download/v0.0.4/release-0.0.4.yaml

--- a/charts/riff-builders/Chart.yaml
+++ b/charts/riff-builders/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: riff-builders
+description: riff builders for kpack
+home: https://projectriff.io
+sources:
+  - https://github.com/projectriff/builder
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff-builders/templates.yaml
+++ b/charts/riff-builders/templates.yaml
@@ -1,0 +1,2 @@
+application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-0.5.0-snapshot-20190919185005-c03e2b38dae2fc7e.yaml
+function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-0.5.0-snapshot-20190919185005-c03e2b38dae2fc7e.yaml

--- a/charts/riff-builders/templates.yaml.tpl
+++ b/charts/riff-builders/templates.yaml.tpl
@@ -1,0 +1,2 @@
+application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
+function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml


### PR DESCRIPTION
Adding two new charts:
- kpack: wraps the kpack release distro
- riff-builders: the kpack equivalent of the knative buildtemplates

Disable the new charts by default until we are ready to fully replace
Knative Build with kpack.