### PR TITLE
Upgrade Knative Serving to 0.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   fatsDir: '$(system.defaultWorkingDirectory)/../fats'
   fatsRepo: projectriff/fats
-  fatsRefspec: dbf50d113cd280e99470852714ed00b6d09215fe # master as of 2019-08-13
+  fatsRefspec: 4faf0a5130eb3c0a449716793da9ab60c8bdd4af # master as of 2019-09-18
   tillerNamespace: kube-system
   tillerServiceAccount: tiller
 

--- a/charts/knative/Chart.yaml
+++ b/charts/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-appVersion: 0.7
+appVersion: 0.9
 description: riff support for Knative
 home: https://projectriff.io
 sources:

--- a/charts/knative/templates.yaml
+++ b/charts/knative/templates.yaml
@@ -1,1 +1,1 @@
-knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.7.1/serving.yaml # --data-value dropKnativeImageCRD=true
+knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.9.0/serving-post-1.14.yaml # --data-value dropKnativeImageCRD=true

--- a/charts/knative/templates.yaml.tpl
+++ b/charts/knative/templates.yaml.tpl
@@ -1,1 +1,1 @@
-knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.8.1/serving.yaml # --data-value dropKnativeImageCRD=true
+knative-serving: https://storage.googleapis.com/knative-releases/serving/previous/v0.9.0/serving-post-1.14.yaml # --data-value dropKnativeImageCRD=true


### PR DESCRIPTION
This also will raise the minimum k8s version to 1.14 and expose the
serving.knative.dev/v1 api group.