### PR TITLE
Add a chart for each riff-system component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,19 @@ repository: charts/fetch-istio.sh charts/package.sh
 	./charts/package.sh istio ${VERSION} repository
 	./charts/package.sh knative ${VERSION} repository
 	./charts/package.sh riff ${VERSION} repository
+	./charts/package.sh riff-build ${VERSION} repository
+	./charts/package.sh riff-core-runtime ${VERSION} repository
+	./charts/package.sh riff-knative-runtime ${VERSION} repository
+	./charts/package.sh riff-streaming-runtime ${VERSION} repository
 
 .PHONY: templates
 templates:
 	./charts/update-template.sh knative
 	./charts/update-template.sh riff
+	./charts/update-template.sh riff-build
+	./charts/update-template.sh riff-core-runtime
+	./charts/update-template.sh riff-knative-runtime
+	./charts/update-template.sh riff-streaming-runtime
 
 .PHONY: clean
 clean:

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -58,7 +58,7 @@ if [ -d ${chart_dir}/charts ] ; then
   cp -LR ${chart_dir}/charts/* ${build_dir}/charts/
 fi
 
-if [ ${chart} == 'riff' ] ; then
+if [ ${chart} == riff* ] ; then
   helm package ${build_dir} --destination ${destination} --version ${version} --app-version ${version}
 else
   helm package ${build_dir} --destination ${destination} --version ${version}

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -58,7 +58,7 @@ if [ -d ${chart_dir}/charts ] ; then
   cp -LR ${chart_dir}/charts/* ${build_dir}/charts/
 fi
 
-if [ ${chart} == riff* ] ; then
+if [[ ${chart} == riff* ]] ; then
   helm package ${build_dir} --destination ${destination} --version ${version} --app-version ${version}
 else
   helm package ${build_dir} --destination ${destination} --version ${version}

--- a/charts/riff-build/Chart.yaml
+++ b/charts/riff-build/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: riff-build
+description: build services for riff
+keywords:
+  - projectriff
+  - riff
+  - faas
+home: https://projectriff.io
+sources:
+  - https://github.com/projectriff
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff-build/templates.yaml
+++ b/charts/riff-build/templates.yaml
@@ -1,0 +1,1 @@
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml

--- a/charts/riff-build/templates.yaml.tpl
+++ b/charts/riff-build/templates.yaml.tpl
@@ -1,0 +1,1 @@
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml

--- a/charts/riff-core-runtime/Chart.yaml
+++ b/charts/riff-core-runtime/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: riff-core-runtime
+description: core runtime for riff
+keywords:
+  - projectriff
+  - riff
+  - faas
+home: https://projectriff.io
+sources:
+  - https://github.com/projectriff
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff-core-runtime/templates.yaml
+++ b/charts/riff-core-runtime/templates.yaml
@@ -1,0 +1,1 @@
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml

--- a/charts/riff-core-runtime/templates.yaml.tpl
+++ b/charts/riff-core-runtime/templates.yaml.tpl
@@ -1,0 +1,1 @@
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml

--- a/charts/riff-knative-runtime/Chart.yaml
+++ b/charts/riff-knative-runtime/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: riff-knative-runtime
+description: knative runtime for riff
+keywords:
+  - projectriff
+  - riff
+  - faas
+home: https://projectriff.io
+sources:
+  - https://github.com/projectriff
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff-knative-runtime/templates.yaml
+++ b/charts/riff-knative-runtime/templates.yaml
@@ -1,0 +1,1 @@
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml

--- a/charts/riff-knative-runtime/templates.yaml.tpl
+++ b/charts/riff-knative-runtime/templates.yaml.tpl
@@ -1,0 +1,1 @@
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml

--- a/charts/riff-streaming-runtime/Chart.yaml
+++ b/charts/riff-streaming-runtime/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: riff-streaming-runtime
+description: streaming runtime for riff
+keywords:
+  - projectriff
+  - riff
+  - faas
+home: https://projectriff.io
+sources:
+  - https://github.com/projectriff
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff-streaming-runtime/templates.yaml
+++ b/charts/riff-streaming-runtime/templates.yaml
@@ -1,0 +1,1 @@
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml

--- a/charts/riff-streaming-runtime/templates.yaml.tpl
+++ b/charts/riff-streaming-runtime/templates.yaml.tpl
@@ -1,0 +1,1 @@
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml


### PR DESCRIPTION
The `0.5.0-snapshot` in the templates.yaml.tpl files should be replaced with `master` once projectriff/system#89 merges