### PR TITLE
Pin URL for riff-system updated all others

### DIFF
--- a/charts/riff-build/templates.yaml
+++ b/charts/riff-build/templates.yaml
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20190923181754-0fc25a91216eec33.yaml

--- a/charts/riff-builders/templates.yaml
+++ b/charts/riff-builders/templates.yaml
@@ -1,2 +1,2 @@
-application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-0.5.0-snapshot-20190920180923-e70e3dbbce7eaccf.yaml
-function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-0.5.0-snapshot-20190920180923-e70e3dbbce7eaccf.yaml
+application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-0.5.0-snapshot-20190922201617-af6cba1619b1ae84.yaml
+function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-0.5.0-snapshot-20190922201617-af6cba1619b1ae84.yaml

--- a/charts/riff-core-runtime/templates.yaml
+++ b/charts/riff-core-runtime/templates.yaml
@@ -1,1 +1,1 @@
-core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20190923181754-0fc25a91216eec33.yaml

--- a/charts/riff-knative-runtime/templates.yaml
+++ b/charts/riff-knative-runtime/templates.yaml
@@ -1,1 +1,1 @@
-knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20190923181754-0fc25a91216eec33.yaml

--- a/charts/riff-streaming-runtime/templates.yaml
+++ b/charts/riff-streaming-runtime/templates.yaml
@@ -1,1 +1,1 @@
-streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20190919165742-f74c595b277e6fe8.yaml
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20190923181754-0fc25a91216eec33.yaml

--- a/charts/riff/templates.yaml
+++ b/charts/riff/templates.yaml
@@ -1,4 +1,4 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-0.4.0-snapshot-20190814193311-6621e5df099ad813.yaml
-riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.5.0-snapshot-20190920180923-e70e3dbbce7eaccf.yaml
-riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.5.0-snapshot-20190920180923-e70e3dbbce7eaccf.yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/riff-system-0.4.0.yaml
+riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-0.5.0-snapshot-20190922201617-af6cba1619b1ae84.yaml
+riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-0.5.0-snapshot-20190922201617-af6cba1619b1ae84.yaml

--- a/charts/riff/templates.yaml.tpl
+++ b/charts/riff/templates.yaml.tpl
@@ -1,4 +1,4 @@
 knative-build: https://storage.googleapis.com/knative-releases/build/previous/v0.7.0/build.yaml
-riff-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-system-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
+riff-system: https://storage.googleapis.com/projectriff/riff-system/riff-system-0.4.0.yaml
 riff-application-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
 riff-function-build-template: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml


### PR DESCRIPTION
Update all templates URLs. The riff-system URL is now pinned to the last
release since it is no longer published as a single artifact. The value
created by the template was no longer valid.