### PR TITLE
allow multiple runtimes to be installed

### DIFF
--- a/charts/riff-build/templates.yaml
+++ b/charts/riff-build/templates.yaml
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20190923181754-0fc25a91216eec33.yaml
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20190923181754-0fc25a91216eec33.yaml # --data-value keepRiffSystemNamespace=true

--- a/charts/riff-build/templates.yaml.tpl
+++ b/charts/riff-build/templates.yaml.tpl
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml # --data-value keepRiffSystemNamespace=true

--- a/overlays/default-values.yaml
+++ b/overlays/default-values.yaml
@@ -3,3 +3,4 @@
 #@data/values
 ---
 dropKnativeImageCRD: false
+keepRiffSystemNamespace: false

--- a/overlays/helm-namespace.yaml
+++ b/overlays/helm-namespace.yaml
@@ -1,0 +1,9 @@
+#@ load("@ytt:overlay", "overlay")
+
+#! replace riff-system with helm provided namespace for all resources
+
+#@overlay/match by=overlay.subset({"metadata":{"namespace":"riff-system"}}), expects="0+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  namespace: '{{ .Release.Namespace }}'

--- a/overlays/helm-namespace.yaml
+++ b/overlays/helm-namespace.yaml
@@ -1,9 +1,0 @@
-#@ load("@ytt:overlay", "overlay")
-
-#! replace riff-system with helm provided namespace for all resources
-
-#@overlay/match by=overlay.subset({"metadata":{"namespace":"riff-system"}}), expects="0+"
----
-metadata:
-  #@overlay/match missing_ok=True
-  namespace: '{{ .Release.Namespace }}'

--- a/overlays/riff-system-namespace.yaml
+++ b/overlays/riff-system-namespace.yaml
@@ -1,0 +1,6 @@
+#@ load("@ytt:overlay", "overlay")
+
+#! Remove riff-system namespace definition
+
+#@overlay/match by=overlay.subset({ "apiVersion": "v1", "kind": "Namespace", "metadata": { "name": "riff-system" } }), expects="0+"
+#@overlay/remove

--- a/overlays/riff-system-namespace.yaml
+++ b/overlays/riff-system-namespace.yaml
@@ -1,6 +1,10 @@
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
 
 #! Remove riff-system namespace definition
 
+#@ if not data.values.keepRiffSystemNamespace:
 #@overlay/match by=overlay.subset({ "apiVersion": "v1", "kind": "Namespace", "metadata": { "name": "riff-system" } }), expects="0+"
 #@overlay/remove
+---
+#@ end


### PR DESCRIPTION
remove the riff-system namespace definition since that prevented
multiple runtimes from being installed in the same namespace. The
namespace can instead be passed along in the `--namespace` flag on
`helm install` command