### PR TITLE
Add riff chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ repository: charts/fetch-istio.sh charts/package.sh
 	./charts/package.sh riff-core-runtime ${VERSION} repository
 	./charts/package.sh riff-knative-runtime ${VERSION} repository
 	./charts/package.sh riff-streaming-runtime ${VERSION} repository
+	./charts/package.sh riff ${VERSION} repository
 
 .PHONY: templates
 templates:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Helm charts to install Istio and riff.
 
 ### Prerequisites
 
-- a running kubernetes cluster (1.11+)
-- kubectl (1.11+)
+- a running kubernetes cluster (1.14+)
+- kubectl (1.14+)
 - helm (2.14+)
 
 ### Steps
@@ -44,7 +44,9 @@ Helm charts to install Istio and riff.
 
    Append:
 
-   - `--set knative.enabled=true` to enable the Knative runtime
+   - `--set riff.runtimes.core.enabled=true` to enable the Core runtime
+   - `--set riff.runtimes.knative.enabled=true` to enable the Knative runtime
+   - `--set riff.runtimes.streaming.enabled=true` to enable the Streaming runtime
    - `--devel` for the latest snapshot.
 
    ```sh

--- a/charts/riff/Chart.yaml
+++ b/charts/riff/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: riff
+description: riff is for functions
+home: https://projectriff.io
+sources:
+  - https://github.com/projectriff
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.14'

--- a/charts/riff/charts/riff-build
+++ b/charts/riff/charts/riff-build
@@ -1,0 +1,1 @@
+../../../build/riff-build

--- a/charts/riff/charts/riff-core-runtime
+++ b/charts/riff/charts/riff-core-runtime
@@ -1,0 +1,1 @@
+../../../build/riff-core-runtime

--- a/charts/riff/charts/riff-knative-runtime
+++ b/charts/riff/charts/riff-knative-runtime
@@ -1,0 +1,1 @@
+../../../build/riff-knative-runtime

--- a/charts/riff/charts/riff-streaming-runtime
+++ b/charts/riff/charts/riff-streaming-runtime
@@ -1,0 +1,1 @@
+../../../build/riff-streaming-runtime

--- a/charts/riff/requirements.yaml
+++ b/charts/riff/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - name: riff-build
+    condition: riff.build.enabled
+  - name: riff-core-runtime
+    condition: riff.runtimes.core.enabled
+  - name: riff-knative-runtime
+    condition: riff.runtimes.knative.enabled
+  - name: riff-streaming-runtime
+    condition: riff.runtimes.streaming.enabled

--- a/charts/riff/values.yaml
+++ b/charts/riff/values.yaml
@@ -1,0 +1,17 @@
+---
+knative:
+  enabled: true
+kpack:
+  enabled: true
+riff:
+  build:
+    enabled: true
+  builders:
+    enabled: true
+  runtimes:
+    core:
+      enabled: false
+    knative:
+      enabled: false
+    streaming:
+      enabled: false

--- a/ci/cleanup-riff.sh
+++ b/ci/cleanup-riff.sh
@@ -10,22 +10,16 @@ uninstall_chart() {
   kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=$name 
 }
 
-if [ $RUNTIME = "core" ]; then
-  echo "Uninstall riff Core Runtime"
-  uninstall_chart riff-core-runtime
-
-elif [ $RUNTIME = "knative" ]; then
-  echo "Uninstall riff Knative Runtime"
-  uninstall_chart riff-knative-runtime
-
+if [ $RUNTIME = "knative" ]; then
+  echo "Uninstall Istio"
   uninstall_chart istio
   # extra cleanup for Istio
   kubectl get customresourcedefinitions.apiextensions.k8s.io -oname | grep istio.io | xargs -L1 kubectl delete
   kubectl delete namespace istio-system
 fi
 
-echo "Uninstall riff Build"
-uninstall_chart riff-build
+echo "Uninstall riff"
+uninstall_chart riff
 
 echo "Uninstall helm"
 helm reset

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -49,4 +49,4 @@ if [ $RUNTIME = "knative" ]; then
 fi
 
 echo "Install riff"
-helm install ${riff_chart} --name riff --set riff.runtimes.${RUNTIME}.enabled=true
+helm install ${riff_chart} --name riff --wait --set riff.runtimes.${RUNTIME}.enabled=true

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -14,17 +14,11 @@ source $FATS_DIR/.configure.sh
 if [ ${1:-unknown} = staged ] ; then
   echo "Using staged charts"
   istio_chart=https://storage.googleapis.com/projectriff/charts/snapshots/istio-${slug}.tgz
-  riff_build_chart=https://storage.googleapis.com/projectriff/charts/snapshots/riff-build-${slug}.tgz
-  riff_core_runtime_chart=https://storage.googleapis.com/projectriff/charts/snapshots/riff-core-runtime-${slug}.tgz
-  riff_knative_runtime_chart=https://storage.googleapis.com/projectriff/charts/snapshots/riff-knative-runtime-${slug}.tgz
-  riff_streaming_runtime_chart=https://storage.googleapis.com/projectriff/charts/snapshots/riff-streaming-runtime-${slug}.tgz
+  riff_chart=https://storage.googleapis.com/projectriff/charts/snapshots/riff-${slug}.tgz
 else
   echo "Using locally built charts"
   istio_chart=./repository/istio-${version}.tgz
-  riff_build_chart=./repository/riff-build-${version}.tgz
-  riff_core_runtime_chart=./repository/riff-core-runtime-${version}.tgz
-  riff_knative_runtime_chart=./repository/riff-knative-runtime-${version}.tgz
-  riff_streaming_runtime_chart=./repository/riff-streaming-runtime-${version}.tgz
+  riff_chart=./repository/riff-${version}.tgz
 fi
 
 tiller_service_account=tiller
@@ -46,17 +40,13 @@ if [ $(kubectl get nodes -oname | wc -l) = "1" ]; then
   wait_pod_selector_ready app=webhook no-resource-requests
 fi
 
-echo "Install riff Build"
-helm install ${riff_build_chart} --name riff-build --set kpack.enabled=true --set riff.builders.enabled=true
-
-if [ $RUNTIME = "core" ]; then
-  echo "Install riff Core Runtime"
-  helm install ${riff_core_runtime_chart} --name riff-core-runtime
-elif [ $RUNTIME = "knative" ]; then
-  echo "Install riff Knative Runtime"
+if [ $RUNTIME = "knative" ]; then
+  echo "Install Istio"
   helm install ${istio_chart} --name istio --namespace istio-system --wait --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
-  helm install ${riff_knative_runtime_chart} --name riff-knative-runtime --set knative.enabled=true
 
   echo "Checking for ready ingress"
   wait_for_ingress_ready 'istio-ingressgateway' 'istio-system'
 fi
+
+echo "Install riff"
+helm install ${riff_chart} --name riff --set riff.runtimes.${RUNTIME}.enabled=true


### PR DESCRIPTION
The riff chart encompasses all other charts (except for Istio). riff
Build and kpack are installed by default, but each runtime must be
explicitly enabled.