### PR TITLE
Resolve known image tags to digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ VERSION ?= $(shell cat VERSION)
 .PHONY: package
 package: repository
 
-repository: charts/fetch-istio.sh charts/package.sh
+.PHONY: repository
+repository:
 	mkdir -p repository
 	./charts/fetch-istio.sh istio 1.2.5
 	./charts/package.sh istio ${VERSION} repository

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   fatsDir: '$(system.defaultWorkingDirectory)/../fats'
   fatsRepo: projectriff/fats
-  fatsRefspec: d26fa5dfd47f5cb74ca44a4fa41db11ec0942f14 # master as of 2019-10-10
+  fatsRefspec: f49faae3d6cba32993fae99c6e39c41d9cd1598a # master as of 2019-10-16
 
 jobs:
 
@@ -39,7 +39,8 @@ jobs:
       $(fatsDir)/install.sh kubectl
       $(fatsDir)/install.sh riff
       $(fatsDir)/install.sh helm
-      $(fatsDir)/install.sh ytt 0.14.0
+      $(fatsDir)/install.sh ytt
+      $(fatsDir)/install.sh kbld
       sudo snap install yq
     displayName: 'Install tools'
   - bash: |

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -31,7 +31,7 @@ if [ -f ${chart_dir}/templates.yaml ] ; then
     mv ${file}.tmp ${file}
 
     # apply ytt overlays
-    ytt -f overlays/ -f ${file} --file-mark $(basename ${file}):type=yaml-plain ${args} > ${file}.tmp
+    ytt -f overlays/ -f ${file} --file-mark $(basename ${file}):type=yaml-plain ${args} | kbld -f - > ${file}.tmp
     mv ${file}.tmp ${file}
   done < "${chart_dir}/templates.yaml"
 fi


### PR DESCRIPTION
Partially resolves https://github.com/projectriff/charts/issues/3 by running `kbld` over the template yaml.

This doesn't resolve the case when the image is constructed via helm values.

Also - if an image tag is mutated and the references in these charts aren't pointed to by a `tag` they may be garbage collected.

