### PR TITLE
use forked keda to install alongside knative

### DIFF
--- a/charts/keda/templates.yaml
+++ b/charts/keda/templates.yaml
@@ -1,1 +1,1 @@
-keda: https://github.com/kedacore/keda/raw/32f9823070a6dfc9cb5ad6100305a171abc6db83/deploy/KedaScaleController.yaml
+keda: https://raw.githubusercontent.com/sbawaska/keda/rm-clusterrole/deploy/KedaScaleController.yaml


### PR DESCRIPTION
This allows streaming runtime to be installed alongside knative runtime.
This is a temporary fix until the PR for this branch is merged.