### PR TITLE
Package cert-manager as a chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ package: repository
 repository: charts/fetch-istio.sh charts/package.sh
 	mkdir -p repository
 	./charts/fetch-istio.sh istio 1.2.5
+	./charts/package.sh cert-manager ${VERSION} repository
 	./charts/package.sh istio ${VERSION} repository
 	./charts/package.sh keda ${VERSION} repository
 	./charts/package.sh knative ${VERSION} repository
@@ -19,6 +20,7 @@ repository: charts/fetch-istio.sh charts/package.sh
 
 .PHONY: templates
 templates:
+	./charts/update-template.sh cert-manager
 	./charts/update-template.sh keda
 	./charts/update-template.sh knative
 	./charts/update-template.sh kpack

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: cert-manager
+appVersion: v0.10.1
+description: riff support for cert-manager
+home: https://projectriff.io
+sources:
+  - https://github.com/jetstack/cert-manager
+icon: https://projectriff.io/images/riff.png
+tillerVersion: '>=2.13'

--- a/charts/cert-manager/templates.yaml
+++ b/charts/cert-manager/templates.yaml
@@ -1,0 +1,1 @@
+cert-manager: https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml

--- a/charts/cert-manager/templates.yaml.tpl
+++ b/charts/cert-manager/templates.yaml.tpl
@@ -1,0 +1,1 @@
+cert-manager: https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml

--- a/ci/cleanup-riff.sh
+++ b/ci/cleanup-riff.sh
@@ -20,5 +20,8 @@ fi
 echo "Uninstall riff"
 uninstall_chart riff
 
+echo "Uninstall Cert Manager"
+uninstall_chart cert-manager
+
 echo "Uninstall helm"
 source $FATS_DIR/macros/helm-reset.sh

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -28,7 +28,13 @@ source $FATS_DIR/macros/helm-init.sh
 echo "Install Cert Manager"
 helm install ${certmanager_chart} --name cert-manager --wait
 
-source $FATS_DIR/macros/no-resource-requests.sh
+# TODO go back to the macro once FATS is updated for the cert-manager chart
+# source $FATS_DIR/macros/no-resource-requests.sh
+if [ $(kubectl get nodes -oname | wc -l) = "1" ]; then
+  echo "Elimiate pod resource requests"
+  fats_retry kubectl apply -f https://storage.googleapis.com/projectriff/no-resource-requests-webhook/no-resource-requests-webhook.yaml
+  wait_pod_selector_ready app=webhook no-resource-requests
+fi
 
 if [ $RUNTIME = "knative" ]; then
   echo "Install Istio"

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -13,16 +13,22 @@ source $FATS_DIR/.configure.sh
 
 if [ ${1:-unknown} = staged ] ; then
   echo "Using staged charts"
+  certmanager_chart=https://storage.googleapis.com/projectriff/charts/snapshots/cert-manager-${slug}.tgz
   istio_chart=https://storage.googleapis.com/projectriff/charts/snapshots/istio-${slug}.tgz
   riff_chart=https://storage.googleapis.com/projectriff/charts/snapshots/riff-${slug}.tgz
 else
   echo "Using locally built charts"
+  certmanager_chart=./repository/cert-manager-${version}.tgz
   istio_chart=./repository/istio-${version}.tgz
   riff_chart=./repository/riff-${version}.tgz
 fi
 
-source $FATS_DIR/macros/no-resource-requests.sh
 source $FATS_DIR/macros/helm-init.sh
+
+echo "Install Cert Manager"
+helm install ${certmanager_chart} --name cert-manager --wait
+
+source $FATS_DIR/macros/no-resource-requests.sh
 
 if [ $RUNTIME = "knative" ]; then
   echo "Install Istio"


### PR DESCRIPTION
Cert Manger is used to issues tls certificats that are consumed by
kubebuilder MutationAdmissionWebhooks and ValidatingAdmissionWebhooks.

FATS will need to be updated to no longer kubectl apply the cert-manager
config in the no-resource-requests macro, but this needs to merge first.

Note: this is cert-manager 0.10, 0.11 introduces breaking changes and
is not backwards/forwards compatible.

Refs projectriff/system#102