### PR TITLE
Update system and builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Helm charts to install Istio and riff.
    - `--set riff.runtimes.core.enabled=true` to enable the Core runtime
    - `--set riff.runtimes.knative.enabled=true` to enable the Knative runtime
    - `--set riff.runtimes.streaming.enabled=true` to enable the Streaming runtime
+   - `--set cert-manager.enabled=false` if cert-manager is already installed
    - `--devel` for the latest snapshot.
 
    ```sh

--- a/charts/riff-build/templates.yaml
+++ b/charts/riff-build/templates.yaml
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20191022095620-b45854af69a13ca3.yaml # --data-value keepRiffSystemNamespace=true
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20191028165954-a61d6619fb9877e1.yaml # --data-value keepRiffSystemNamespace=true

--- a/charts/riff-builders/templates.yaml
+++ b/charts/riff-builders/templates.yaml
@@ -1,2 +1,2 @@
-application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-0.5.0-snapshot-20191023020421-0ad36267ab2d123f.yaml
-function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-0.5.0-snapshot-20191023020421-0ad36267ab2d123f.yaml
+application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-0.5.0-snapshot-20191028213133-9291b5996d4044c8.yaml
+function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-0.5.0-snapshot-20191028213133-9291b5996d4044c8.yaml

--- a/charts/riff-core-runtime/templates.yaml
+++ b/charts/riff-core-runtime/templates.yaml
@@ -1,1 +1,1 @@
-core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20191022095620-b45854af69a13ca3.yaml
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20191028165954-a61d6619fb9877e1.yaml

--- a/charts/riff-knative-runtime/templates.yaml
+++ b/charts/riff-knative-runtime/templates.yaml
@@ -1,1 +1,1 @@
-knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20191022095620-b45854af69a13ca3.yaml
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20191028165954-a61d6619fb9877e1.yaml

--- a/charts/riff-streaming-runtime/templates.yaml
+++ b/charts/riff-streaming-runtime/templates.yaml
@@ -1,1 +1,1 @@
-streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20191022095620-b45854af69a13ca3.yaml
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20191028165954-a61d6619fb9877e1.yaml

--- a/charts/riff/charts/cert-manager
+++ b/charts/riff/charts/cert-manager
@@ -1,0 +1,1 @@
+../../../build/cert-manager

--- a/charts/riff/requirements.yaml
+++ b/charts/riff/requirements.yaml
@@ -1,4 +1,6 @@
 dependencies:
+  - name: cert-manager
+    condition: cert-manager.enabled
   - name: riff-build
     condition: riff.build.enabled
   - name: riff-core-runtime

--- a/charts/riff/values.yaml
+++ b/charts/riff/values.yaml
@@ -1,4 +1,6 @@
 ---
+cert-manager:
+  enabled: true
 keda:
   enabled: true
 knative:

--- a/ci/install-riff.sh
+++ b/ci/install-riff.sh
@@ -39,4 +39,6 @@ if [ $RUNTIME = "knative" ]; then
 fi
 
 echo "Install riff"
-helm install ${riff_chart} --name riff --wait --set riff.runtimes.${RUNTIME}.enabled=true
+helm install ${riff_chart} --name riff --wait \
+  --set cert-manager.enabled=false \
+  --set riff.runtimes.${RUNTIME}.enabled=true


### PR DESCRIPTION
Cert-manager is now required. It will be installed with the riff chart
by default, or can be installed independently with the cert-manager
chart.