### PR TITLE
Add hook-delete-policy to delete existing CRDs before creation

### DIFF
--- a/overlays/crd-install.yml
+++ b/overlays/crd-install.yml
@@ -9,3 +9,4 @@ metadata:
   annotations:
     #@overlay/match missing_ok=True
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": before-hook-creation


### PR DESCRIPTION
- this should allow us to install, delete and install again without having to explicitly delete CRDs