### PR TITLE
Template Istio version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 VERSION ?= $(shell cat VERSION)
+export ISTIO_VERSION = 1.3.3
 
 .PHONY: package
 package: repository
 
 repository: charts/fetch-istio.sh charts/package.sh
 	mkdir -p repository
-	./charts/fetch-istio.sh istio 1.3.3
+	./charts/fetch-istio.sh istio $(ISTIO_VERSION)
 	./charts/package.sh cert-manager ${VERSION} repository
 	./charts/package.sh istio ${VERSION} repository
 	./charts/package.sh keda ${VERSION} repository

--- a/charts/apply-template.sh
+++ b/charts/apply-template.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+template=${1}
+comment=${2:-#}
+
+if [ -f $template ] ; then
+  echo "${comment} DO NOT EDIT - this file is the output of the '$template' template "
+  while IFS= read -r line
+  do
+    expressions=$(echo $line | grep -oE '\{\{[^}]+\}\}') || true
+    while read -r expression; do
+      if [[ $expression == "{{tpl_escape"* ]]; then
+        output=$(echo $expression | sed -e 's/^{{tpl_escape/{{/')
+      else
+        output=$(eval $(echo $expression | sed -e 's/^{{//g' | sed -e 's/}}$//g'))
+      fi
+      line=${line//$expression/$output}
+    done <<< "$expressions"
+    echo "$line"
+  done < "$template"
+fi

--- a/charts/istio/.gitignore
+++ b/charts/istio/.gitignore
@@ -1,0 +1,1 @@
+/values.yaml

--- a/charts/istio/values.yaml.tpl
+++ b/charts/istio/values.yaml.tpl
@@ -7,9 +7,9 @@ global:
     accessLogFile: "/dev/stdout"
     accessLogEncoding: 'JSON'
     autoInject: disabled
-    image: docker.io/istio/proxyv2:1.3.3
+    image: docker.io/istio/proxyv2:{{ echo $ISTIO_VERSION }}
   proxy_init:
-    image: docker.io/istio/proxy_init:1.3.3
+    image: docker.io/istio/proxy_init:{{ echo $ISTIO_VERSION }}
   disablePolicyChecks: true
   omitSidecarInjectorConfigMap: true
   defaultPodDisruptionBudget:
@@ -19,10 +19,10 @@ global:
   # This is noop until this merges https://github.com/istio/istio/pull/18642
   # and is backported to a release riff is using
   kubectl:
-    image: docker.io/istio/kubectl:1.3.3
+    image: docker.io/istio/kubectl:{{ echo $ISTIO_VERSION }}
 
 sidecarInjectorWebhook:
-  image: docker.io/istio/sidecar_injector:1.3.3
+  image: docker.io/istio/sidecar_injector:{{ echo $ISTIO_VERSION }}
   enabled: false
   enableNamespacesByDefault: false
 
@@ -71,7 +71,7 @@ prometheus:
   enabled: false
 
 mixer:
-  image: docker.io/istio/mixer:1.3.3
+  image: docker.io/istio/mixer:{{ echo $ISTIO_VERSION }}
   enabled: false
   policy:
     enabled: false
@@ -82,7 +82,7 @@ mixer:
       enabled: false
 
 pilot:
-  image: docker.io/istio/pilot:1.3.3
+  image: docker.io/istio/pilot:{{ echo $ISTIO_VERSION }}
   traceSampling: 100
   sidecar: false
   resources:
@@ -91,13 +91,13 @@ pilot:
       memory: 256Mi
 
 galley:
-  image: docker.io/istio/galley:1.3.3
+  image: docker.io/istio/galley:{{ echo $ISTIO_VERSION }}
   enabled: false
 
 security:
-  image: docker.io/istio/citadel:1.3.3
+  image: docker.io/istio/citadel:{{ echo $ISTIO_VERSION }}
   enabled: false
 
 nodeagent:
-  image: docker.io/istio/node-agent-k8s:1.3.3
+  image: docker.io/istio/node-agent-k8s:{{ echo $ISTIO_VERSION }}
 

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -40,6 +40,10 @@ if [ -f ${chart_dir}/templates.yaml ] ; then
   done < "${chart_dir}/templates.yaml"
 fi
 
+if [ -f ${chart_dir}/values.yaml.tpl ] ; then
+  $( dirname "${BASH_SOURCE[0]}" )/apply-template.sh ${chart_dir}/values.yaml.tpl > ${chart_dir}/values.yaml
+fi
+
 if [ -f ${chart_dir}/values.yaml ] ; then
   if [ -f ${build_dir}/values.yaml ] ; then
     # merge custom values

--- a/charts/riff-build/templates.yaml.tpl
+++ b/charts/riff-build/templates.yaml.tpl
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml # --data-value keepRiffSystemNamespace=true
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-{{ curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master }}.yaml # --data-value keepRiffSystemNamespace=true

--- a/charts/riff-builders/templates.yaml.tpl
+++ b/charts/riff-builders/templates.yaml.tpl
@@ -1,2 +1,2 @@
-application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
-function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-$(curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master).yaml
+application-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-application-clusterbuilder-{{ curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master }}.yaml
+function-builder: https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-function-clusterbuilder-{{ curl -s https://storage.googleapis.com/projectriff/riff-buildtemplate/versions/builds/master }}.yaml

--- a/charts/riff-core-runtime/templates.yaml.tpl
+++ b/charts/riff-core-runtime/templates.yaml.tpl
@@ -1,1 +1,1 @@
-core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-{{ curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master }}.yaml

--- a/charts/riff-knative-runtime/templates.yaml.tpl
+++ b/charts/riff-knative-runtime/templates.yaml.tpl
@@ -1,1 +1,1 @@
-knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-{{ curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master }}.yaml

--- a/charts/riff-streaming-runtime/templates.yaml.tpl
+++ b/charts/riff-streaming-runtime/templates.yaml.tpl
@@ -1,1 +1,1 @@
-streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-$(curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master).yaml
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-{{ curl -s https://storage.googleapis.com/projectriff/riff-system/snapshots/versions/master }}.yaml

--- a/charts/update-template.sh
+++ b/charts/update-template.sh
@@ -5,9 +5,5 @@ chart=$1
 chart_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/${chart}"
 
 if [ -f $chart_dir/templates.yaml.tpl ] ; then
-  rm  $chart_dir/templates.yaml
-  while IFS= read -r line
-  do
-    eval "echo \"${line}\" >> $chart_dir/templates.yaml"
-  done < "$chart_dir/templates.yaml.tpl"
+  $( dirname "${BASH_SOURCE[0]}" )/apply-template.sh $chart_dir/templates.yaml.tpl >  $chart_dir/templates.yaml
 fi


### PR DESCRIPTION
We should avoid hard coding the Istio version in the Istio values.yaml
file. By templating the values we can resolve the Istio version and
consume new Istio releases by updating a single value.

This also updates the template format to evaluate expressions within
`{{ expr }}` instead of evaluating every line as a shell expression.
This makes escaping values that should not be matched much simpler as
only `{{ ... }}` will be evaluated.

Follow up to #78