### PR TITLE
Add crd-upgrade hook

### DIFF
--- a/charts/riff-build/templates.yaml
+++ b/charts/riff-build/templates.yaml
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20191105195703-de4bccac5f36277a.yaml # --data-value keepRiffSystemNamespace=true
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20191107001535-76223d757087daf7.yaml # --data-value keepRiffSystemNamespace=true

--- a/charts/riff-core-runtime/templates.yaml
+++ b/charts/riff-core-runtime/templates.yaml
@@ -1,1 +1,1 @@
-core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20191105195703-de4bccac5f36277a.yaml
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20191107001535-76223d757087daf7.yaml

--- a/charts/riff-knative-runtime/templates.yaml
+++ b/charts/riff-knative-runtime/templates.yaml
@@ -1,1 +1,1 @@
-knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20191105195703-de4bccac5f36277a.yaml
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20191107001535-76223d757087daf7.yaml

--- a/charts/riff-streaming-runtime/templates.yaml
+++ b/charts/riff-streaming-runtime/templates.yaml
@@ -1,1 +1,1 @@
-streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20191105195703-de4bccac5f36277a.yaml
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20191107001535-76223d757087daf7.yaml

--- a/overlays/crd-install.yml
+++ b/overlays/crd-install.yml
@@ -8,5 +8,6 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     #@overlay/match missing_ok=True
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook": "crd-install,crd-upgrade"
+    #@overlay/match missing_ok=True
+    "helm.sh/hook-delete-policy": "before-hook-creation"


### PR DESCRIPTION
- this allows us to upgrade a release and add additional runtimes like:

    helm install projectriff/riff --name riff --set tags.core-runtime=true --set tags.knative-runtime=false --wait --devel
    helm upgrade riff projectriff/riff --set tags.core-runtime=true --set tags.knative-runtime=true --wait --devel