### PR TITLE
Update KEDA to v1.0.0

### DIFF
--- a/charts/keda/Chart.yaml
+++ b/charts/keda/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keda
-appVersion: 0.0.0-snapshot
+appVersion: 1.0.0
 description: riff support for keda
 home: https://projectriff.io
 sources:

--- a/charts/keda/templates.yaml
+++ b/charts/keda/templates.yaml
@@ -1,1 +1,9 @@
-keda: https://github.com/kedacore/keda/raw/fed1348af0c393186c931e482021b10413bad62e/deploy/KedaScaleController.yaml
+namespace: https://storage.googleapis.com/projectriff/charts/extras/keda/keda-namespace.yaml
+crd-scaledobject: https://github.com/kedacore/keda/raw/v1.0.0/deploy/crds/keda.k8s.io_scaledobjects_crd.yaml
+crd-triggerauthentications: https://github.com/kedacore/keda/raw/v1.0.0/deploy/crds/keda.k8s.io_triggerauthentications_crd.yaml
+api-service: https://github.com/kedacore/keda/raw/v1.0.0/deploy/api_service.yaml
+operator: https://github.com/kedacore/keda/raw/v1.0.0/deploy/operator.yaml
+role: https://github.com/kedacore/keda/raw/v1.0.0/deploy/role.yaml
+role-binding: https://github.com/kedacore/keda/raw/v1.0.0/deploy/role_binding.yaml
+service: https://github.com/kedacore/keda/raw/v1.0.0/deploy/service.yaml
+service-account: https://github.com/kedacore/keda/raw/v1.0.0/deploy/service_account.yaml


### PR DESCRIPTION
There is no longer a single file, so we have many more URLs to download,
the namespace is also missing, so I created that resource and hosted on
our GCS bucket directly.