### PR TITLE
Publish kafka as an (un)chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 env:
   FATS_DIR: fats
   FATS_REPO: projectriff/fats
-  FATS_REFSPEC: b10e06684d38ce450cb718b9af94b568f8319a06 # master as of 2019-11-21
+  FATS_REFSPEC: 06aacf672daaf1ab70ad4e7db9846037eaf1340a # master as of 2019-11-22
 
 jobs:
 

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,15 @@ repository: charts/*.sh
 
 	./charts/package.sh cert-manager ${VERSION}
 	./charts/unpackage.sh cert-manager
-	
+
 	./charts/fetch-istio.sh istio $(ISTIO_VERSION)
 	./charts/package.sh istio ${VERSION}
 	./charts/unpackage.sh istio
 
+	./charts/fetch-kafka.sh kafka 0.20.5
+	./charts/package.sh kafka ${VERSION}
+	./charts/unpackage.sh kafka
+	
 	./charts/package.sh keda ${VERSION}
 	./charts/unpackage.sh keda
 	

--- a/charts/fetch-kafka.sh
+++ b/charts/fetch-kafka.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+chart=$1
+version=$2
+
+build_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )/build/${chart}"
+
+mkdir -p ${build_dir}
+curl -L -s https://kubernetes-charts-incubator.storage.googleapis.com/kafka-${version}.tgz | tar xz -C ${build_dir} --strip-components 1
+
+cat ${build_dir}/Chart.yaml | sed -e "s/name: kafka/name: ${chart}/g" > ${build_dir}/Chart.yaml.tmp
+mv ${build_dir}/Chart.yaml.tmp ${build_dir}/Chart.yaml

--- a/charts/kafka/overlays-uncharted/inject-namespace.yaml
+++ b/charts/kafka/overlays-uncharted/inject-namespace.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+
+#! Add missing namespace to resources
+
+#@overlay/match by=overlay.all,expects="0+"
+---
+#@overlay/match missing_ok=True
+metadata:
+  #@overlay/match missing_ok=True
+  namespace: kafka
+
+#@overlay/match by=overlay.subset({"kind": "Namespace"}),expects="0+"
+---
+metadata:
+  #@overlay/remove
+  namespace:

--- a/charts/kafka/overlays-uncharted/no-hooks.yaml
+++ b/charts/kafka/overlays-uncharted/no-hooks.yaml
@@ -1,0 +1,7 @@
+#@ load("@ytt:overlay", "overlay")
+
+#! Remove resources with helm hooks
+
+#@overlay/match by=overlay.subset({ "metadata": { "annotations": { "helm.sh/hook": "test-success" } } }), expects="0+"
+#@overlay/remove
+---

--- a/charts/kafka/uncharted.patch
+++ b/charts/kafka/uncharted.patch
@@ -1,0 +1,8 @@
+1a2,8
+> # PATCH #1: Creating the kafka namespace.
+> apiVersion: v1
+> kind: Namespace
+> metadata:
+>   name: kafka
+> # PATCH #1 ends.
+> ---

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -1,0 +1,5 @@
+replicas: 1
+zookeeper:
+  replicaCount: 1
+  env:
+    ZK_HEAP_SIZE: 128m

--- a/charts/package.sh
+++ b/charts/package.sh
@@ -54,7 +54,7 @@ fi
 
 # Resolve any image tags to digests in our values.yaml
 if [ -f ${build_dir}/values.yaml ] ; then
-    k8s-tag-resolver ${build_dir}/values.yaml -o ${build_dir}/values.yaml.tmp
+    k8s-tag-resolver ${build_dir}/values.yaml -o ${build_dir}/values.yaml.tmp || cp ${build_dir}/values.yaml ${build_dir}/values.yaml.tmp
     mv ${build_dir}/values.yaml.tmp ${build_dir}/values.yaml
 fi
 

--- a/charts/unpackage.sh
+++ b/charts/unpackage.sh
@@ -30,6 +30,12 @@ fi
 if [ $chart == "istio" ] ; then
   helm template ./repository/istio-*.tgz --namespace istio-system > ${file}
 fi
+if [ $chart == "kafka" ] ; then
+  helm template ./repository/kafka-*.tgz --namespace kafka > ${file}
+
+  cat ${file} | sed -e 's/release-name-//g' | sed -e 's/release-name/riff/g' > ${file}.tmp
+  mv ${file}.tmp ${file}
+fi
 
 if [ -f ${chart_dir}/uncharted.patch ] ; then
   patch ${file} ${chart_dir}/uncharted.patch


### PR DESCRIPTION
We don't want to support a kafka install as part of riff, yet we need
kafka for our own tests. This chart/unchart is intended to fill that gap
but is not intended for end-users.