### PR TITLE
Publish latest System

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 env:
   FATS_DIR: fats
   FATS_REPO: projectriff/fats
-  FATS_REFSPEC: 06aacf672daaf1ab70ad4e7db9846037eaf1340a # master as of 2019-11-22
+  FATS_REFSPEC: 696bfb86ab8111c1945b81a661629d7dd70388e7 # master as of 2019-12-08
 
 jobs:
 

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -13,6 +13,8 @@ fats_create_push_credentials $NAMESPACE
 for test in java java-boot node npm command; do
   name=fats-cluster-uppercase-${test}
   image=$(fats_image_repo ${name})
+  curl_opts="-H Content-Type:text/plain -H Accept:text/plain -d charts"
+  expected_data="CHARTS"
 
   echo "##[group]Run function $name"
 
@@ -24,7 +26,20 @@ for test in java java-boot node npm command; do
     --ingress-policy External \
     --namespace $NAMESPACE \
     --tail
-  source ${FATS_DIR}/macros/invoke_${RUNTIME}_deployer.sh $name "-H Content-Type:text/plain -H Accept:text/plain -d charts" CHARTS
+  if [ $RUNTIME = "core" ]; then
+    # TODO also test external ingress for core runtime
+    source ${FATS_DIR}/macros/invoke_incluster.sh \
+      "$(kubectl get deployers.${RUNTIME}.projectriff.io ${name} --namespace ${NAMESPACE} -ojsonpath='{.status.address.url}')" \
+      "${curl_opts}" \
+      "${expected_data}"
+  fi
+  if [ $RUNTIME = "knative" ]; then
+    # TODO also test clusterlocal ingress for knative runtime
+    source ${FATS_DIR}/macros/invoke_${RUNTIME}_deployer.sh \
+      $name \
+      "${curl_opts}" \
+      "${expected_data}"
+  fi
   riff $RUNTIME deployer delete $name --namespace $NAMESPACE
 
   riff function delete $name --namespace $NAMESPACE

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -9,6 +9,7 @@ source $FATS_DIR/.configure.sh
 # setup namespace
 kubectl create namespace $NAMESPACE
 fats_create_push_credentials $NAMESPACE
+source ${FATS_DIR}/macros/create-riff-dev-pod.sh
 
 for test in java java-boot node npm command; do
   name=fats-cluster-uppercase-${test}

--- a/charts/riff-build/templates.yaml
+++ b/charts/riff-build/templates.yaml
@@ -1,1 +1,1 @@
-build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20191207152521-a461d22ba38834bd.yaml
+build-system: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-build-0.5.0-snapshot-20191209200325-a3c3350d38eab3a8.yaml

--- a/charts/riff-core-runtime/templates.yaml
+++ b/charts/riff-core-runtime/templates.yaml
@@ -1,1 +1,1 @@
-core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20191207152521-a461d22ba38834bd.yaml
+core-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-core-0.5.0-snapshot-20191209200325-a3c3350d38eab3a8.yaml

--- a/charts/riff-knative-runtime/templates.yaml
+++ b/charts/riff-knative-runtime/templates.yaml
@@ -1,1 +1,1 @@
-knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20191207152521-a461d22ba38834bd.yaml
+knative-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-knative-0.5.0-snapshot-20191209200325-a3c3350d38eab3a8.yaml

--- a/charts/riff-streaming-runtime/templates.yaml
+++ b/charts/riff-streaming-runtime/templates.yaml
@@ -1,1 +1,1 @@
-streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20191207152521-a461d22ba38834bd.yaml
+streaming-runtime: https://storage.googleapis.com/projectriff/riff-system/snapshots/riff-streaming-0.5.0-snapshot-20191209200325-a3c3350d38eab3a8.yaml


### PR DESCRIPTION
This introduces two breaking changes:
- PodTemplateSpec has replaced PodSpec at `.spec.template`. The PodSpec
  is now available at `.spec.template.spec`
- `.status.*Name` fields are now references named `.status.*Ref`. The
  name is available at `.status.*Ref.name`. Where the name was
  previously an empty string, the reference is nil.